### PR TITLE
ISSUE-114: fix character enconding string

### DIFF
--- a/sdk/core/network/src/main/kotlin/com/vk/id/network/http/FormBody.kt
+++ b/sdk/core/network/src/main/kotlin/com/vk/id/network/http/FormBody.kt
@@ -122,7 +122,7 @@ public class FormBody private constructor(
          * @return the URL-encoded string
          */
         private fun urlEncode(value: String): String {
-            return URLEncoder.encode(value, StandardCharsets.UTF_8.toString())
+            return URLEncoder.encode(value, StandardCharsets.UTF_8.name())
         }
     }
 }

--- a/sdk/core/network/src/main/kotlin/com/vk/id/network/util/CreateRequest.kt
+++ b/sdk/core/network/src/main/kotlin/com/vk/id/network/util/CreateRequest.kt
@@ -65,5 +65,5 @@ internal fun createUrl(
 }
 
 private fun urlEncode(value: String): String {
-    return URLEncoder.encode(value, StandardCharsets.UTF_8.toString())
+    return URLEncoder.encode(value, StandardCharsets.UTF_8.name())
 }

--- a/sdk/core/network/src/test/kotlin/com/vk/id/network/http/FormBodyTest.kt
+++ b/sdk/core/network/src/test/kotlin/com/vk/id/network/http/FormBodyTest.kt
@@ -64,8 +64,8 @@ internal class FormBodyTest : BehaviorSpec({
 
             Then("should URL-encode special characters") {
                 val content = formBody.content()
-                val expectedEmail = URLEncoder.encode("test@example.com", StandardCharsets.UTF_8.toString())
-                val expectedMessage = URLEncoder.encode("Hello World!", StandardCharsets.UTF_8.toString())
+                val expectedEmail = URLEncoder.encode("test@example.com", StandardCharsets.UTF_8.name())
+                val expectedMessage = URLEncoder.encode("Hello World!", StandardCharsets.UTF_8.name())
                 content shouldBe "email=$expectedEmail&message=$expectedMessage"
             }
         }
@@ -176,7 +176,7 @@ internal class FormBodyTest : BehaviorSpec({
 
             Then("should properly encode special symbols") {
                 val content = formBody.content()
-                val expected = URLEncoder.encode("!@#$%^&*()", StandardCharsets.UTF_8.toString())
+                val expected = URLEncoder.encode("!@#$%^&*()", StandardCharsets.UTF_8.name())
                 content shouldBe "symbols=$expected"
             }
         }
@@ -188,7 +188,7 @@ internal class FormBodyTest : BehaviorSpec({
 
             Then("should properly encode unicode") {
                 val content = formBody.content()
-                val expected = URLEncoder.encode("Привет мир", StandardCharsets.UTF_8.toString())
+                val expected = URLEncoder.encode("Привет мир", StandardCharsets.UTF_8.name())
                 content shouldBe "text=$expected"
             }
         }


### PR DESCRIPTION
#114
Заменил `StandardCharsets.UTF_8.toString()` на `StandardCharsets.UTF_8.name()`.

Проблема в том, что на старых версиях Android, в конкретном случае Android 6.x.x метод toString() возвращает строку "java.nio.charset.CharsetICU[UTF-8]", которая не является валидной кодировкой. 

В более свежих версиях метод `toString()` вызывает `name()`, который возвращает, как ожидается, "UTF-8".  
В старых же версиях не так. Тем не менее `name()` сам по себе работает одинаково для разных версий.

Можно было бы также просто прописать строкой "UTF-8", но я вижу в коде другие использования `StandardCharsets.UTF_8`, т.ч. оставил в общем стиле.

